### PR TITLE
proposal for handling rectilinear fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ ENV/
 
 # IDE settings
 .vscode/
+
+# local cmake install
+cmake*

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ class CMakeBuild(build_ext):
                 "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE",
                 "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir),
             ]
-            if sys.maxsize > 2 ** 32:
+            if sys.maxsize > 2**32:
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:

--- a/xdrt/xdr_reader.py
+++ b/xdrt/xdr_reader.py
@@ -374,20 +374,17 @@ def read(xdr_filename, stop_before_data=False):
 
         header.grid_spacing = list(reversed(grid_spacing))
 
-
     else:
         # AVSField standard defines the min_ext and max_ext based on final bytes.
         for _ in range(header.ndim):
             header.min_ext.append(np.fromfile(file_handler, dtype=">f4", count=1)[0] * 10.0)  # * 10. to convert to mm.
             header.max_ext.append(np.fromfile(file_handler, dtype=">f4", count=1)[0] * 10.0)  # * 10. to convert to mm.
 
-        
         if not header.ndim == len(header.min_ext) == len(header.max_ext):
             raise IOError(
                 f"Dimension {header.ndim} must match length of min_ext and max_ext."
                 f" Got {header.ndim}, {header.min_ext} and {header.max_ext}"
             )
-
 
     if file_handler.tell() != path.getsize(xdr_filename):
         file_handler.close()
@@ -395,7 +392,6 @@ def read(xdr_filename, stop_before_data=False):
 
     file_handler.close()
 
-    
     shape = header.shape
 
     if header.veclen != 1:


### PR DESCRIPTION
Fixes the problem with rectilinear fields.
This is done by introducing a new spacing system called "grid_spacing" which keeps the spacing for each dimension separately as a numpy array which indicates the location of each element in that dimension.
The absence of scan to siddon is not considered breaking anymore, as some files don't have it but are valid xdr files (at least from experience).
